### PR TITLE
Allocate a namespace for the DfT project

### DIFF
--- a/2024/dft.md
+++ b/2024/dft.md
@@ -1,0 +1,8 @@
+# DfT namespace
+
+This URL prefix, `https://apollo-protocol.github.io/ns/2024/dft`, is
+allocated for use by a project conducted on behalf of the Department for
+Transport.
+
+The URLs under this namespace are used as IRIs in RDF. They are not
+publically documented at this time.

--- a/ns.md
+++ b/ns.md
@@ -9,3 +9,6 @@ Currently-allocated prefixes are:
 * [2023/diagram-editor](./2023/diagram-editor) Allocated to the
   prototype [4D activity diagram
   editor](https://github.com/Apollo-Protocol/4d-activity-editor).
+
+* [2024/dft](./2024/dft) Allocated to a project for the
+  Department for Transport.


### PR DESCRIPTION
We need a namespace to use pending a more permanent allocation from the DfT.